### PR TITLE
feat: Add support for all ink!-compatible chains

### DIFF
--- a/.changeset/shiny-panthers-fold.md
+++ b/.changeset/shiny-panthers-fold.md
@@ -1,0 +1,5 @@
+---
+'@scio-labs/use-inkathon': minor
+---
+
+Added native support for more !ink compatible testnets (t0rn, Bit.Country, Peaq, Pendulum, Phala) and mainnets (Khala, Phala, Amplitude, Pendulum)

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -74,6 +74,91 @@ export const shibuya: SubstrateChain = {
   faucetUrls: ['https://portal.astar.network/#/shibuya-testnet/assets'],
 }
 
+export const t0rn: SubstrateChain = {
+  network: 't0rn',
+  name: 'T0rn Testnet',
+  ss58Prefix: 42,
+  rpcUrls: ['wss://ws.t0rn.io'],
+  explorerUrls: {
+    [SubstrateExplorer.PolkadotJs]: `https://polkadot.js.org/apps/?rpc=${encodeURIComponent(
+      'wss://ws.t0rn.io',
+    )}/#/explorer`,
+  },
+  testnet: true,
+  faucetUrls: ['https://faucet.t0rn.io'],
+}
+
+export const bitCountryAlphaTestnet: SubstrateChain = {
+  network: 'bitcountry-alpha-testnet',
+  name: 'Bit.Country Alpha Testnet',
+  ss58Prefix: 268,
+  rpcUrls: ['wss://alphanet-rpc-gcp.bit.country'],
+  explorerUrls: {
+    [SubstrateExplorer.PolkadotJs]: `https://polkadot.js.org/apps/?rpc=${encodeURIComponent(
+      'wss://alphanet-rpc-gcp.bit.country',
+    )}#/explorer`,
+  },
+  testnet: true,
+  faucetUrls: ['https://testnet.bit.country/p/wallet/balance'],
+}
+
+export const agungTestnet: SubstrateChain = {
+  network: 'agung-testnet',
+  name: 'Agung Testnet (Peaq Network)',
+  ss58Prefix: 42,
+  rpcUrls: ['wss://wss.agung.peaq.network'],
+  explorerUrls: {
+    [SubstrateExplorer.Subscan]: `https://agung-testnet.subscan.io/`,
+    [SubstrateExplorer.PolkadotJs]: `https://polkadot.js.org/apps/?rpc=${encodeURIComponent(
+      'wss://wss.agung.peaq.network',
+    )}/#/explorer`,
+  },
+  testnet: true,
+  faucetUrls: ['https://discord.com/channels/943486047625572392/963415793394143232'],
+}
+
+export const rococoAmplitudeTestnet: SubstrateChain = {
+  network: 'rococo-amplitude-testnet',
+  name: 'Amplitude Testnet (Foucoco)',
+  ss58Prefix: 57,
+  rpcUrls: ['wss://pencol-roc-00.pendulumchain.tech'],
+  explorerUrls: {
+    [SubstrateExplorer.PolkadotJs]: `https://polkadot.js.org/apps/?rpc=${encodeURIComponent(
+      'wss://pencol-roc-00.pendulumchain.tech',
+    )}/#/explorer`,
+  },
+  testnet: true,
+  faucetUrls: [],
+}
+
+export const phalaPOC5Testnet: SubstrateChain = {
+  network: 'phala-PoC-5-testnet',
+  name: 'Phala PoC-5 Testnet',
+  ss58Prefix: 30,
+  rpcUrls: ['wss://poc5.phala.network'],
+  explorerUrls: {
+    [SubstrateExplorer.PolkadotJs]: `https://polkadot.js.org/apps/?rpc=${encodeURIComponent(
+      'wss://poc5.phala.network/ws',
+    )}#/explorer`,
+  },
+  testnet: true,
+  faucetUrls: [],
+}
+
+export const phalaPOC6Testnet: SubstrateChain = {
+  network: 'phala-PoC-6-testnet',
+  name: 'Phala PoC-6 Testnet',
+  ss58Prefix: 30,
+  rpcUrls: ['wss://poc6.phala.network'],
+  explorerUrls: {
+    [SubstrateExplorer.PolkadotJs]: `https://polkadot.js.org/apps/?rpc=${encodeURIComponent(
+      'wss://poc6.phala.network/ws',
+    )}#/explorer`,
+  },
+  testnet: true,
+  faucetUrls: [],
+}
+
 /// Canary Networks (Kusama)
 
 export const shiden: SubstrateChain = {
@@ -83,6 +168,36 @@ export const shiden: SubstrateChain = {
   rpcUrls: ['wss://shiden-rpc.dwellir.com'],
   explorerUrls: {
     [SubstrateExplorer.Subscan]: `https://shiden.subscan.io`,
+  },
+}
+
+export const amplitude: SubstrateChain = {
+  network: 'amplitude',
+  name: 'Amplitude',
+  ss58Prefix: 57,
+  rpcUrls: ['wss://rpc-amplitude.pendulumchain.tech', 'wss://amplitude-rpc.dwellir.com'],
+  explorerUrls: {
+    [SubstrateExplorer.PolkadotJs]: `https://polkadot.js.org/apps/?rpc=${encodeURIComponent(
+      'wss://rpc-amplitude.pendulumchain.tech',
+    )}#/explorer`,
+  },
+}
+
+export const khala: SubstrateChain = {
+  network: 'khala',
+  name: 'Khala',
+  ss58Prefix: 30,
+  rpcUrls: [
+    'wss://khala-api.phala.network/ws',
+    'wss://khala.api.onfinality.io/public-ws',
+    'wss://khala-rpc.dwellir.com',
+    'wss://public-rpc.pinknode.io/khala',
+  ],
+  explorerUrls: {
+    [SubstrateExplorer.PolkadotJs]: `https://polkadot.js.org/apps/?rpc=${encodeURIComponent(
+      'wss://khala-api.phala.network/ws',
+    )}#/explorer`,
+    [SubstrateExplorer.Subscan]: `https://khala.subscan.io`,
   },
 }
 
@@ -109,7 +224,31 @@ export const astar: SubstrateChain = {
   explorerUrls: {
     [SubstrateExplorer.Subscan]: `https://astar.subscan.io`,
   },
-  faucetUrls: [],
+}
+
+export const pendulum: SubstrateChain = {
+  network: 'pendulum',
+  name: 'Pendulum',
+  ss58Prefix: 56,
+  rpcUrls: ['wss://rpc-pendulum.prd.pendulumchain.tech', 'wss://pendulum-rpc.dwellir.com'],
+  explorerUrls: {
+    [SubstrateExplorer.PolkadotJs]: `https://polkadot.js.org/apps/?rpc=${encodeURIComponent(
+      'wss://rpc-pendulum.prd.pendulumchain.tech',
+    )}#/explorer`,
+  },
+}
+
+export const phala: SubstrateChain = {
+  network: 'phala',
+  name: 'Phala',
+  ss58Prefix: 30,
+  rpcUrls: ['wss://api.phala.network/ws', 'wss://phala.api.onfinality.io/public-ws'],
+  explorerUrls: {
+    [SubstrateExplorer.PolkadotJs]: `https://polkadot.js.org/apps/?rpc=${encodeURIComponent(
+      'wss://api.phala.network/ws',
+    )}#/explorer`,
+    [SubstrateExplorer.Subscan]: `https://phala.subscan.io`,
+  },
 }
 
 /**
@@ -119,10 +258,20 @@ export const allSubstrateChains: SubstrateChain[] = [
   development,
   alephzeroTestnet,
   rococo,
+  t0rn,
+  bitCountryAlphaTestnet,
+  agungTestnet,
+  rococoAmplitudeTestnet,
+  phalaPOC5Testnet,
+  phalaPOC6Testnet,
   shibuya,
   shiden,
+  amplitude,
+  khala,
   alephzero,
   astar,
+  pendulum,
+  phala,
 ]
 
 /**

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -1,26 +1,9 @@
-/**
- * Substrate Chain Type
- */
-export interface SubstrateChain {
-  network: string
-  name: string
-  rpcUrls: [string, ...string[]]
-  ss58Prefix?: number
-  explorerUrls?: Partial<Record<SubstrateExplorer, string>>
-  testnet?: boolean
-  faucetUrls?: string[]
-}
-
-export enum SubstrateExplorer {
-  Subscan = 'subscan',
-  PolkadotJs = 'polkadotjs',
-}
+import { SubstrateChain, SubstrateExplorer } from '@/types'
 
 /**
- * Defined Substrate Chain Constants
+ * Local Development Network
  */
 
-/// Local Development Network
 export const development: SubstrateChain = {
   network: 'development',
   name: 'Local Development',
@@ -35,7 +18,9 @@ export const development: SubstrateChain = {
   faucetUrls: ['https://polkadot.js.org/apps/#/accounts?rpc=ws://127.0.0.1:9944'],
 }
 
-/// Testnets
+/**
+ * Live Testnets
+ */
 
 export const alephzeroTestnet: SubstrateChain = {
   network: 'alephzero-testnet',
@@ -53,7 +38,8 @@ export const alephzeroTestnet: SubstrateChain = {
 
 export const rococo: SubstrateChain = {
   network: 'rococo',
-  name: 'Rococo',
+  name: 'Rococo Contracts Testnet',
+  ss58Prefix: 42,
   rpcUrls: ['wss://rococo-contracts-rpc.polkadot.io'],
   explorerUrls: {
     [SubstrateExplorer.Subscan]: `https://rococo.subscan.io`,
@@ -74,7 +60,7 @@ export const shibuya: SubstrateChain = {
   faucetUrls: ['https://portal.astar.network/#/shibuya-testnet/assets'],
 }
 
-export const t0rn: SubstrateChain = {
+export const t0rnTestnet: SubstrateChain = {
   network: 't0rn',
   name: 'T0rn Testnet',
   ss58Prefix: 42,
@@ -104,7 +90,7 @@ export const bitCountryAlphaTestnet: SubstrateChain = {
 
 export const agungTestnet: SubstrateChain = {
   network: 'agung-testnet',
-  name: 'Agung Testnet (Peaq Network)',
+  name: 'Agung Testnet',
   ss58Prefix: 42,
   rpcUrls: ['wss://wss.agung.peaq.network'],
   explorerUrls: {
@@ -117,9 +103,9 @@ export const agungTestnet: SubstrateChain = {
   faucetUrls: ['https://discord.com/channels/943486047625572392/963415793394143232'],
 }
 
-export const rococoAmplitudeTestnet: SubstrateChain = {
-  network: 'rococo-amplitude-testnet',
-  name: 'Amplitude Testnet (Foucoco)',
+export const amplitudeTestnet: SubstrateChain = {
+  network: 'amplitude-testnet',
+  name: 'Amplitude Testnet',
   ss58Prefix: 57,
   rpcUrls: ['wss://pencol-roc-00.pendulumchain.tech'],
   explorerUrls: {
@@ -135,7 +121,7 @@ export const phalaPOC5Testnet: SubstrateChain = {
   network: 'phala-PoC-5-testnet',
   name: 'Phala PoC-5 Testnet',
   ss58Prefix: 30,
-  rpcUrls: ['wss://poc5.phala.network'],
+  rpcUrls: ['wss://poc5.phala.network/ws'],
   explorerUrls: {
     [SubstrateExplorer.PolkadotJs]: `https://polkadot.js.org/apps/?rpc=${encodeURIComponent(
       'wss://poc5.phala.network/ws',
@@ -145,21 +131,9 @@ export const phalaPOC5Testnet: SubstrateChain = {
   faucetUrls: [],
 }
 
-export const phalaPOC6Testnet: SubstrateChain = {
-  network: 'phala-PoC-6-testnet',
-  name: 'Phala PoC-6 Testnet',
-  ss58Prefix: 30,
-  rpcUrls: ['wss://poc6.phala.network'],
-  explorerUrls: {
-    [SubstrateExplorer.PolkadotJs]: `https://polkadot.js.org/apps/?rpc=${encodeURIComponent(
-      'wss://poc6.phala.network/ws',
-    )}#/explorer`,
-  },
-  testnet: true,
-  faucetUrls: [],
-}
-
-/// Canary Networks (Kusama)
+/**
+ * Live Canary Networks
+ */
 
 export const shiden: SubstrateChain = {
   network: 'shiden',
@@ -201,7 +175,9 @@ export const khala: SubstrateChain = {
   },
 }
 
-/// Mainnets
+/**
+ * Live Mainnet Networks
+ */
 
 export const alephzero: SubstrateChain = {
   network: 'alephzero',
@@ -258,12 +234,11 @@ export const allSubstrateChains: SubstrateChain[] = [
   development,
   alephzeroTestnet,
   rococo,
-  t0rn,
+  t0rnTestnet,
   bitCountryAlphaTestnet,
   agungTestnet,
-  rococoAmplitudeTestnet,
+  amplitudeTestnet,
   phalaPOC5Testnet,
-  phalaPOC6Testnet,
   shibuya,
   shiden,
   amplitude,

--- a/src/helpers/initPolkadotJs.ts
+++ b/src/helpers/initPolkadotJs.ts
@@ -1,4 +1,4 @@
-import { SubstrateChain } from '@/chains'
+import { SubstrateChain } from '@/types'
 import { ApiPromise, HttpProvider, WsProvider } from '@polkadot/api'
 import { ApiOptions } from '@polkadot/api/types'
 

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -1,6 +1,8 @@
 import { accountArraysAreEqual, accountsAreEqual, initPolkadotJs } from '@/helpers'
 import { registerDeployments } from '@/registry'
 import {
+  SubstrateChain,
+  SubstrateDeployment,
   SubstrateWallet,
   UseInkathonError,
   UseInkathonErrorCode,
@@ -18,8 +20,7 @@ import { ApiOptions } from '@polkadot/api/types'
 import { InjectedAccount, InjectedExtension, Unsubcall } from '@polkadot/extension-inject/types'
 import { Signer } from '@polkadot/types/types'
 import { FC, PropsWithChildren, createContext, useContext, useEffect, useState } from 'react'
-import { SubstrateChain, getSubstrateChain } from './chains'
-import { SubstrateDeployment } from './types/SubstrateDeployment'
+import { getSubstrateChain } from './chains'
 
 const UseInkathonProviderContext = createContext<UseInkathonProviderContextType | null>(null)
 

--- a/src/types/SubstrateChain.ts
+++ b/src/types/SubstrateChain.ts
@@ -1,0 +1,17 @@
+/**
+ * Substrate Chain Type
+ */
+export interface SubstrateChain {
+  network: string
+  name: string
+  rpcUrls: [string, ...string[]]
+  ss58Prefix?: number
+  explorerUrls?: Partial<Record<SubstrateExplorer, string>>
+  testnet?: boolean
+  faucetUrls?: string[]
+}
+
+export enum SubstrateExplorer {
+  Subscan = 'subscan',
+  PolkadotJs = 'polkadotjs',
+}

--- a/src/types/UseInkathonProviderContext.ts
+++ b/src/types/UseInkathonProviderContext.ts
@@ -1,9 +1,9 @@
 import { SubstrateWallet } from '@/types'
+import { SubstrateChain } from '@/types/SubstrateChain'
 import { ApiPromise, HttpProvider, WsProvider } from '@polkadot/api'
 import { InjectedAccount, InjectedExtension } from '@polkadot/extension-inject/types'
 import { Signer } from '@polkadot/types/types'
 import { Dispatch, SetStateAction } from 'react'
-import { SubstrateChain } from '../chains'
 import { SubstrateDeployment } from './SubstrateDeployment'
 
 export type UseInkathonProviderContextType = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 // @index('./*.ts', f => `export * from '${f.path}'`)
 export * from './ChainAsset'
+export * from './SubstrateChain'
 export * from './SubstrateDeployment'
 export * from './SubstrateWallet'
 export * from './UseInkathonProviderContext'


### PR DESCRIPTION
Closes #28 

Added chains:
- [x] [Testnet] t3rn (t0rn)
- [x] [Testnet] Bit.Country
- [x] [Testnet] peaq (Agung)
- [x] [Testnet] Pendulum
- [x] [Testnet] Phala PoC-5 & Phala PoC-6
- [x] [Mainnet] Khala
- [x] [Mainnet] Phala
- [x] [Mainnet] Amplitude
- [x] [Mainnet] Pendulum    

To add:
- [ ] [Testnet] Enjin -> won't be added as there's no support for !ink anymore (see the comment below)