### PR TITLE
Update Phala testnet endpoint URL

### DIFF
--- a/.changeset/long-forks-study.md
+++ b/.changeset/long-forks-study.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+Update Phala testnet endpoint URL

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -117,18 +117,18 @@ export const amplitudeTestnet: SubstrateChain = {
   faucetUrls: [],
 }
 
-export const phalaPOC5Testnet: SubstrateChain = {
-  network: 'phala-PoC-5-testnet',
-  name: 'Phala PoC-5 Testnet',
+export const phalaPOC6Testnet: SubstrateChain = {
+  network: 'phala-PoC-6-testnet',
+  name: 'Phala PoC-6 Testnet',
   ss58Prefix: 30,
-  rpcUrls: ['wss://poc5.phala.network/ws'],
+  rpcUrls: ['wss://poc6.phala.network/ws'],
   explorerUrls: {
     [SubstrateExplorer.PolkadotJs]: `https://polkadot.js.org/apps/?rpc=${encodeURIComponent(
-      'wss://poc5.phala.network/ws',
+      'wss://poc6.phala.network/ws',
     )}#/explorer`,
   },
   testnet: true,
-  faucetUrls: [],
+  faucetUrls: ['https://phala.network/faucet'],
 }
 
 /**
@@ -238,7 +238,7 @@ export const allSubstrateChains: SubstrateChain[] = [
   bitCountryAlphaTestnet,
   agungTestnet,
   amplitudeTestnet,
-  phalaPOC5Testnet,
+  phalaPOC6Testnet,
   shibuya,
   shiden,
   amplitude,


### PR DESCRIPTION
The PoC5 testnet is deprecated and took down soon, so this PR propose for update the endpoint URL to the testnet.