### PR TITLE
fix: prevent silent failing during contract creation

### DIFF
--- a/.changeset/real-bats-enjoy.md
+++ b/.changeset/real-bats-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@scio-labs/use-inkathon': minor
+---
+
+throws Error when trying to access unavailable contract deployment

--- a/src/helpers/getDeployment.ts
+++ b/src/helpers/getDeployment.ts
@@ -29,7 +29,6 @@ export const getDeploymentContract = (
   contractId: string,
   networkId: string,
 ) => {
-  if (!api) return undefined
   const deployment = getDeployment(deployments || [], contractId, networkId)
   if (!deployment) return undefined
   return new ContractPromise(api, deployment?.abi, deployment?.address)

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -19,8 +19,12 @@ export const useContract = (
       setContract(undefined)
       return
     }
-    const contract = new ContractPromise(api, abi, address)
-    setContract(contract)
+    try {
+      const contract = new ContractPromise(api, abi, address)
+      setContract(contract)
+    } catch (error) {
+      console.error('Error during Contract initialization', error)
+    }
   }
   useEffect(() => {
     initialize()

--- a/src/hooks/useRegisteredContract.ts
+++ b/src/hooks/useRegisteredContract.ts
@@ -9,7 +9,14 @@ import { useContract } from './useContract'
  */
 export const useRegisteredContract = (contractId: string, networkId?: string) => {
   const { deployments, activeChain } = useInkathon()
+
   networkId = networkId || activeChain?.network || ''
+
   const deployment = getDeployment(deployments || [], contractId, networkId)
-  return useContract(deployment?.abi, deployment?.address)
+
+  if (!deployment) {
+    throw new Error(`No deployment found for contractId ${contractId} on network ${networkId}`)
+  }
+
+  return useContract(deployment.abi, deployment.address)
 }

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -254,7 +254,7 @@ export const UseInkathonProvider: FC<UseInkathonProviderProps> = ({
     }
   }, [api])
 
-  // Initialze
+  // Initialize
   useEffect(() => {
     if (isInitialized.current || isInitializing.current) return
     connectOnInit ? connect() : initialize()


### PR DESCRIPTION
While using the hooks I experience serveral times that my `contract` instance from `useContract` or `useRegisteredContract` was plainly `undefined`. 

The creation of the contract or fetching the deployment information just failed silently. This PR is meant to make it more transparent to the user if this happens.