### PR TITLE
fix: marks `rococo` as deprecated and should be replaced with `contracts`

### DIFF
--- a/.changeset/rude-coats-invent.md
+++ b/.changeset/rude-coats-invent.md
@@ -1,0 +1,5 @@
+---
+'@scio-labs/use-inkathon': minor
+---
+
+marks `rococo` chains data as deprecated and should be replaced with `contracts`, as `rococo` is the testnet relay chain not the smart contracts chain users interact with

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -36,6 +36,9 @@ export const alephzeroTestnet: SubstrateChain = {
   faucetUrls: ['https://faucet.test.azero.dev'],
 }
 
+/**
+ * @deprecated Use `contracts` instead, which is the smart contracts parachain of Rococo.
+ */
 export const rococo: SubstrateChain = {
   network: 'rococo',
   name: 'Rococo Contracts Testnet',
@@ -43,6 +46,18 @@ export const rococo: SubstrateChain = {
   rpcUrls: ['wss://rococo-contracts-rpc.polkadot.io'],
   explorerUrls: {
     [SubstrateExplorer.Subscan]: `https://rococo.subscan.io`,
+  },
+  testnet: true,
+  faucetUrls: ['https://matrix.to/#/#rococo-faucet:matrix.org'],
+}
+
+export const contracts: SubstrateChain = {
+  network: 'contracts',
+  name: 'Contracts on Rococo',
+  ss58Prefix: 42,
+  rpcUrls: ['wss://rococo-contracts-rpc.polkadot.io'],
+  explorerUrls: {
+    [SubstrateExplorer.PolkadotJs]: `https://polkadot.js.org/apps/?rpc=wss%253A%252F%252Frococo-contracts-rpc.polkadot.io`,
   },
   testnet: true,
   faucetUrls: ['https://matrix.to/#/#rococo-faucet:matrix.org'],

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -36,21 +36,6 @@ export const alephzeroTestnet: SubstrateChain = {
   faucetUrls: ['https://faucet.test.azero.dev'],
 }
 
-/**
- * @deprecated Use `contracts` instead, which is the smart contracts parachain of Rococo.
- */
-export const rococo: SubstrateChain = {
-  network: 'rococo',
-  name: 'Rococo Contracts Testnet',
-  ss58Prefix: 42,
-  rpcUrls: ['wss://rococo-contracts-rpc.polkadot.io'],
-  explorerUrls: {
-    [SubstrateExplorer.Subscan]: `https://rococo.subscan.io`,
-  },
-  testnet: true,
-  faucetUrls: ['https://matrix.to/#/#rococo-faucet:matrix.org'],
-}
-
 export const contracts: SubstrateChain = {
   network: 'contracts',
   name: 'Contracts on Rococo',
@@ -62,6 +47,11 @@ export const contracts: SubstrateChain = {
   testnet: true,
   faucetUrls: ['https://matrix.to/#/#rococo-faucet:matrix.org'],
 }
+
+/**
+ * @deprecated Use `contracts` instead, which is the smart contracts parachain of Rococo.
+ */
+export const rococo: SubstrateChain = contracts
 
 export const shibuya: SubstrateChain = {
   network: 'shibuya',


### PR DESCRIPTION
We should use the correct names of the networks we interact with. Rococo is the relay chain and not capable of any smart contract interaction. We always talk to the `Contracts` parachain of Rococo. We should make this clear to resolve confusions. I agree the name `contracts` for a parachain is not very insightful, but that is what we are stuck with right now. :)