### PR TITLE
add supportedWallets value to provider

### DIFF
--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -52,6 +52,7 @@ export interface UseInkathonProviderProps extends PropsWithChildren {
   connectOnInit?: boolean
   deployments?: Promise<SubstrateDeployment[]>
   apiOptions?: ApiOptions
+  supportedWallets?: SubstrateWallet[]
 }
 export const UseInkathonProvider: FC<UseInkathonProviderProps> = ({
   children,
@@ -60,6 +61,7 @@ export const UseInkathonProvider: FC<UseInkathonProviderProps> = ({
   connectOnInit,
   deployments: _deployments,
   apiOptions,
+  supportedWallets = allSubstrateWallets,
 }) => {
   // Check if default chain was provided
   if (
@@ -182,7 +184,7 @@ export const UseInkathonProvider: FC<UseInkathonProviderProps> = ({
 
     try {
       // Determine installed wallets
-      const wallets = allSubstrateWallets.filter((w) => isWalletInstalled(w))
+      const wallets = supportedWallets.filter((w) => isWalletInstalled(w))
       if (!wallets?.length) {
         const message = 'No Substrate-compatible extension detected'
         setError({
@@ -290,6 +292,7 @@ export const UseInkathonProvider: FC<UseInkathonProviderProps> = ({
         setActiveAccount,
         lastActiveAccount,
         deployments,
+        supportedWallets,
       }}
     >
       {children}

--- a/src/types/UseInkathonProviderContext.ts
+++ b/src/types/UseInkathonProviderContext.ts
@@ -28,6 +28,7 @@ export type UseInkathonProviderContextType = {
   setActiveAccount?: Dispatch<SetStateAction<InjectedAccount | undefined>>
   lastActiveAccount?: InjectedAccount
   deployments?: SubstrateDeployment[]
+  supportedWallets?: SubstrateWallet[]
 }
 
 export interface UseInkathonError {


### PR DESCRIPTION
A fix to https://github.com/scio-labs/use-inkathon/issues/67 where a `supportedWallets` value is added to the provider which defaults to `allSubstrateWallets`. It allows dapp developers to set the wallet extensions a dapp supports. The initial reason for this change was that `nightlyWallet` was enabled by default and gave popups to dapp users that have no wallet installed. It can also be used to e.g. populate a connection button like in the example with a limited set of wallets.


See a live version of the change here: 
https://stake-n-vote-rmcf.vercel.app/

with this repo:
https://github.com/TheKusamarian/stake-n-vote/blob/d253734a4d99c36fd88f126e06f82d06925fa5e5/app/providers.tsx#L25