### PR TITLE
chore: add new Testnet Pop-Network

### DIFF
--- a/.changeset/shaggy-countries-decide.md
+++ b/.changeset/shaggy-countries-decide.md
@@ -1,0 +1,5 @@
+---
+"@scio-labs/use-inkathon": minor
+---
+
+aadds smart contract capable Pop Network to defined chains

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -36,6 +36,18 @@ export const alephzeroTestnet: SubstrateChain = {
   faucetUrls: ['https://faucet.test.azero.dev'],
 }
 
+export const popNetwork: SubstrateChain = {
+  network: 'pop-network',
+  name: 'Pop Network',
+  ss58Prefix: 42,
+  rpcUrls: ['wss://rpc1.paseo.popnetwork.xyz', 'wss://rpc2.paseo.popnetwork.xyz'],
+  explorerUrls: {
+    [SubstrateExplorer.PolkadotJs]: `https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc1.paseo.popnetwork.xyz`,
+  },
+  testnet: true,
+  faucetUrls: ['https://faucet.polkadot.io/'],
+}
+
 export const contracts: SubstrateChain = {
   network: 'contracts',
   name: 'Contracts on Rococo',

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -36,11 +36,15 @@ export const alephzeroTestnet: SubstrateChain = {
   faucetUrls: ['https://faucet.test.azero.dev'],
 }
 
-export const popNetwork: SubstrateChain = {
-  network: 'pop-network',
+export const popNetworkTestnet: SubstrateChain = {
+  network: 'pop-network-testnet',
   name: 'Pop Network',
   ss58Prefix: 42,
-  rpcUrls: ['wss://rpc1.paseo.popnetwork.xyz', 'wss://rpc2.paseo.popnetwork.xyz'],
+  rpcUrls: [
+    'wss://rpc1.paseo.popnetwork.xyz',
+    'wss://rpc2.paseo.popnetwork.xyz',
+    'wss://rpc3.paseo.popnetwork.xyz',
+  ],
   explorerUrls: {
     [SubstrateExplorer.PolkadotJs]: `https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc1.paseo.popnetwork.xyz`,
   },

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -292,6 +292,7 @@ export const allSubstrateChains: SubstrateChain[] = [
   t0rnTestnet,
   ternoa,
   ternoaAlphanet,
+  popNetworkTestnet,
 ]
 
 /**


### PR DESCRIPTION
New pallet-contracts supporting testnet on the block.
Probably the replacement for `rococo.contracts`

https://popnetwork.xyz/