### PR TITLE
Fix frozen balance

### DIFF
--- a/.changeset/tiny-geese-yawn.md
+++ b/.changeset/tiny-geese-yawn.md
@@ -1,0 +1,5 @@
+---
+'@scio-labs/use-inkathon': patch
+---
+
+Fix frozen balance

--- a/src/helpers/getBalance.ts
+++ b/src/helpers/getBalance.ts
@@ -35,7 +35,6 @@ export const getBalance = async (
   // Query the chain and parse data
   const result: any = await api.query.system.account(address)
   const balanceData = parseBalanceData(api, result?.data, formatterOptions)
-
   return balanceData
 }
 
@@ -84,11 +83,9 @@ const parseBalanceData = (
   const balance = reservedBalance.add(freeBalance)
 
   // Calculate the reducible balance (see: https://substrate.stackexchange.com/a/3009/3470)
-  const miscFrozenBalance: BN = new BN(data?.miscFrozen || 0)
-  const feeFrozenBalance: BN = new BN(data?.feeFrozen || 0)
-  const reducibleBalance = freeBalance.sub(
-    miscFrozenBalance.gt(feeFrozenBalance) ? miscFrozenBalance : feeFrozenBalance,
-  )
+  // (https://wiki.polkadot.network/docs/learn-guides-accounts#query-account-data-in-polkadot-js)
+  const frozenBalance: BN = new BN(data?.frozen || 0)
+  const reducibleBalance = freeBalance.sub(frozenBalance.sub(reservedBalance))
 
   // Format the balance
   const freeBalanceFormatted = formatBalance(api, freeBalance, formatterOptions)

--- a/src/helpers/getBalance.ts
+++ b/src/helpers/getBalance.ts
@@ -84,8 +84,18 @@ const parseBalanceData = (
 
   // Calculate the reducible balance (see: https://substrate.stackexchange.com/a/3009/3470)
   // (https://wiki.polkadot.network/docs/learn-guides-accounts#query-account-data-in-polkadot-js)
-  const frozenBalance: BN = new BN(data?.frozen || 0)
-  const reducibleBalance = freeBalance.sub(frozenBalance.sub(reservedBalance))
+  let reducibleBalance = new BN(0)
+
+  if (data?.frozen) {
+    const frozenBalance: BN = new BN(data?.frozen || 0)
+    reducibleBalance = freeBalance.sub(frozenBalance.sub(reservedBalance))
+  } else {
+    const miscFrozenBalance: BN = new BN(data?.miscFrozen || 0)
+    const feeFrozenBalance: BN = new BN(data?.feeFrozen || 0)
+    reducibleBalance = freeBalance.sub(
+      miscFrozenBalance.gt(feeFrozenBalance) ? miscFrozenBalance : feeFrozenBalance,
+    )
+  }
 
   // Format the balance
   const freeBalanceFormatted = formatBalance(api, freeBalance, formatterOptions)


### PR DESCRIPTION
See issue #83 
polkadot.js frozen balance is data?.frozen not data?.miscFrozen and data?.feeFrozen
[See the following return type](https://wiki.polkadot.network/docs/learn-guides-accounts#query-account-data-in-polkadot-js)

To verify this is working, 

In TransferDialog.tsx replace this line:
`const { tokenSymbol, tokenDecimals, reducibleBalance } = useBalance(activeAccount?.address, true)`

with:

```
const { tokenSymbol, tokenDecimals, reducibleBalance } = useBalance(
    '5FKbRdY3LSH3u7i5HQtZJFUDYK48gVDTk9UHfLVReB2V7iCe',
    true,
  )
```

and see the difference


I pushed out two commits. The second one prevents any breaking changes in case data?.miscFrozen and data?.feeFrozen exist on other chains. The first replaces them all together